### PR TITLE
Load API keys from .env with template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,15 @@
+# Copy this file to .env and fill in the values.
+
+# Choose the framework: "openai" (default) or "aladdin"
+ANSWER_FRAMEWORK=openai
+
+# OpenAI configuration
+OPENAI_API_KEY=your_openai_key_here
+# Optional: override the default model
+OPENAI_MODEL=gpt-5-nano
+
+# Aladdin custom framework configuration
+aladdin_studio_api_key=your_aladdin_key_here
+defaultWebServer=https://webster.example.com
+aladdin_user=your_service_account_username
+aladdin_passwd=your_service_account_password

--- a/rfp_docx_slot_finder.py
+++ b/rfp_docx_slot_finder.py
@@ -47,6 +47,10 @@ import math
 import asyncio
 from dataclasses import dataclass, asdict
 from typing import List, Optional, Dict, Any, Tuple, Union
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv(override=True)
 
 import docx
 from docx.text.paragraph import Paragraph


### PR DESCRIPTION
## Summary
- Load environment variables from a `.env` file in `rfp_docx_slot_finder.py`
- Provide `.env.template` illustrating required API keys and settings

## Testing
- `python -m py_compile rfp_docx_slot_finder.py`
- `python rfp_docx_slot_finder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a12440eefc83289daceeab05a28657