### PR TITLE
Use Optional for Python <3.10 compatibility

### DIFF
--- a/rfp_docx_apply_answers.py
+++ b/rfp_docx_apply_answers.py
@@ -381,7 +381,7 @@ def apply_answers_to_docx(
     slots = (slots_payload or {}).get("slots", [])
 
     # First pass: resolve answers from file or schedule generation
-    answers: Dict[str, object | None] = {}
+    answers: Dict[str, Optional[object]] = {}
     to_generate: List[Tuple[str, str, dict]] = []
     for s in slots:
         sid = s.get("id", "")
@@ -405,7 +405,7 @@ def apply_answers_to_docx(
 
     # Run generator concurrently for all missing answers
     if to_generate:
-        async def run_all() -> List[Tuple[str, object | None]]:
+        async def run_all() -> List[Tuple[str, Optional[object]]]:
             async def worker(sid: str, q: str, kwargs: dict):
                 try:
                     ans = await asyncio.to_thread(generator, q, **kwargs)

--- a/rfp_pipeline.py
+++ b/rfp_pipeline.py
@@ -13,7 +13,7 @@ import os
 import sys
 import tempfile
 import importlib
-from typing import Callable
+from typing import Callable, Optional
 
 from rfp_handlers import get_handlers
 
@@ -87,7 +87,7 @@ def main() -> None:
         return
 
     # Optional answer generator
-    gen_callable: Callable[[str], str] | None = None
+    gen_callable: Optional[Callable[[str], str]] = None
     gen_name = ""
     if args.generate:
         if ":" not in args.generate:


### PR DESCRIPTION
## Summary
- Replace PEP 604 `| None` unions with `Optional` in `rfp_docx_apply_answers.py` and `rfp_pipeline.py` to avoid runtime TypeErrors on Python versions prior to 3.10

## Testing
- `python -m py_compile rfp_docx_apply_answers.py`
- `python -m py_compile rfp_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a252f949fc83288b8607b14857c2b5