### PR TITLE
Harden paragraph insertion when applying answers

### DIFF
--- a/tests/test_insert_paragraph_after.py
+++ b/tests/test_insert_paragraph_after.py
@@ -1,0 +1,12 @@
+import pytest
+import docx
+from rfp_docx_apply_answers import insert_paragraph_after
+
+
+def test_insert_paragraph_after_requires_paragraph():
+    doc = docx.Document()
+    p = doc.add_paragraph("first")
+    new_p = insert_paragraph_after(p, "second")
+    assert new_p.text == "second"
+    with pytest.raises(TypeError):
+        insert_paragraph_after("not a paragraph", "text")


### PR DESCRIPTION
## Summary
- Validate that `insert_paragraph_after` receives a real python-docx `Paragraph`
- Use `_p` for compatibility and clearer errors when anchor objects are wrong
- Add regression test for `insert_paragraph_after`

## Testing
- `pytest -q`
- `python rfp_docx_apply_answers.py What.docx slots.json answers.json -o out.docx`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd8eb7b083288073234f04cf113d