### PR TITLE
Add basic Excel sheet extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+__pycache__/
+.pytest_cache/

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,8 @@ __all__ = [
     "my_module",
     "rfp_docx_apply_answers",
     "rfp_docx_slot_finder",
+    "rfp_xlsx_slot_finder",
+    "rfp_xlsx_apply_answers",
     "rfp_pipeline",
     "rfp_handlers",
     "answer_composer",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ openai==1.99.9
 pydantic==2.11.7
 pydantic_core==2.33.2
 python-docx==1.2.0
+openpyxl==3.1.2
 python-dotenv==1.0.1
 sniffio==1.3.1
 tqdm==4.67.1

--- a/rfp_handlers.py
+++ b/rfp_handlers.py
@@ -26,6 +26,10 @@ FILE_HANDLERS: Dict[str, Tuple[str, str, str, str]] = {
         "rfp_docx_slot_finder", "extract_slots_from_docx",
         "rfp_docx_apply_answers", "apply_answers_to_docx",
     ),
+    ".xlsx": (
+        "rfp_xlsx_slot_finder", "extract_slots_from_xlsx",
+        "rfp_xlsx_apply_answers", "apply_answers_to_xlsx",
+    ),
 }
 
 

--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -1,0 +1,17 @@
+"""Placeholder apply-answers module for .xlsx files.
+
+Currently only extraction of text/formatting is supported.  This module
+exists so that ``rfp_handlers`` can register an answer applier for the
+``.xlsx`` extension.  The function defined here simply raises
+``NotImplementedError``.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def apply_answers_to_xlsx(xlsx_path: str, slots_json: str, answers_json: str, out_path: str) -> Dict[str, str]:
+    raise NotImplementedError("Excel answer application not yet implemented")
+
+
+__all__ = ["apply_answers_to_xlsx"]

--- a/rfp_xlsx_slot_finder.py
+++ b/rfp_xlsx_slot_finder.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+import openpyxl
+from openpyxl.styles import Color
+from openpyxl.utils import get_column_letter
+
+
+def _color_to_hex(color: Optional[Color]) -> Optional[str]:
+    """Convert an openpyxl Color to a RGB hex string.
+
+    openpyxl colors may include an alpha channel (ARGB).  This helper
+    normalizes them to ``RRGGBB`` if possible.  If the color is theme- or
+    indexed-based, ``None`` is returned.
+    """
+    if color is None:
+        return None
+    if getattr(color, "type", None) != "rgb":
+        return None
+    rgb = getattr(color, "rgb", None)
+    if not isinstance(rgb, str):
+        return None
+    # ``rgb`` is usually ``AARRGGBB``; drop the alpha channel if present
+    if len(rgb) == 8:
+        rgb = rgb[2:]
+    return rgb
+
+
+def extract_slots_from_xlsx(path: str) -> Dict[str, Any]:
+    """Extract text and formatting from an .xlsx file.
+
+    The returned structure mirrors the DOCX slot finder in spirit but is
+    simplified.  It returns a dictionary with ``doc_type`` set to
+    ``"xlsx"`` and a ``sheets`` list, where each sheet contains a list of
+    populated cells.  Each cell records its address (e.g. ``A1``), the
+    text value, and basic formatting attributes (font color, bold,
+    italic, background color, and border styles).
+    """
+    wb = openpyxl.load_workbook(path, data_only=True)
+    sheets: List[Dict[str, Any]] = []
+    for ws in wb.worksheets:
+        cells: List[Dict[str, Any]] = []
+        for row in ws.iter_rows():
+            for cell in row:
+                if cell.value is None:
+                    continue
+                cell_info: Dict[str, Any] = {
+                    "address": cell.coordinate,
+                    "row": cell.row,
+                    "column": get_column_letter(cell.column),
+                    "value": str(cell.value),
+                    "font_color": _color_to_hex(cell.font.color),
+                    "bold": bool(cell.font.bold),
+                    "italic": bool(cell.font.italic),
+                    "bg_color": _color_to_hex(cell.fill.start_color),
+                    "border": {
+                        "left": cell.border.left.style,
+                        "right": cell.border.right.style,
+                        "top": cell.border.top.style,
+                        "bottom": cell.border.bottom.style,
+                    },
+                }
+                cells.append(cell_info)
+        sheets.append({"name": ws.title, "cells": cells})
+    return {"doc_type": "xlsx", "file": os.path.basename(path), "sheets": sheets}
+
+
+__all__ = ["extract_slots_from_xlsx"]

--- a/tests/test_xlsx_extraction.py
+++ b/tests/test_xlsx_extraction.py
@@ -1,0 +1,29 @@
+import openpyxl
+from rfp_xlsx_slot_finder import extract_slots_from_xlsx
+
+
+def test_extract_slots_from_xlsx(tmp_path):
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Sheet1"
+    c = ws1["A1"]
+    c.value = "Question?"
+    c.font = openpyxl.styles.Font(color="FFFF0000", bold=True)
+    c.fill = openpyxl.styles.PatternFill("solid", fgColor="FFFFFF00")
+    ws2 = wb.create_sheet("Data")
+    ws2["B2"] = "Answer"
+
+    path = tmp_path / "sample.xlsx"
+    wb.save(path)
+
+    result = extract_slots_from_xlsx(str(path))
+    assert result["doc_type"] == "xlsx"
+    sheets = {s["name"]: s for s in result["sheets"]}
+    assert set(sheets.keys()) == {"Sheet1", "Data"}
+
+    sheet1_cells = {cell["address"]: cell for cell in sheets["Sheet1"]["cells"]}
+    assert sheet1_cells["A1"]["value"] == "Question?"
+    assert sheet1_cells["A1"]["bold"] is True
+    assert sheet1_cells["A1"]["font_color"].upper().endswith("FF0000")
+    data_cells = {cell["address"]: cell for cell in sheets["Data"]["cells"]}
+    assert data_cells["B2"]["value"] == "Answer"


### PR DESCRIPTION
## Summary
- support `.xlsx` files in handler registry
- add `extract_slots_from_xlsx` to pull cell text and formatting from Excel sheets
- include initial tests for Excel extraction and add `openpyxl` dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48f76c0e48328b757857265d5f4da