### PR TITLE
Add debug before language model call

### DIFF
--- a/qa_core.py
+++ b/qa_core.py
@@ -135,7 +135,18 @@ def answer_question(
     # 3) Call the model
     if DEBUG:
         print("[qa_core] calling language model")
-    content, _usage = llm.get_completion(prompt)
+        print(f"[qa_core] prompt:\n{prompt}")
+        print(f"[qa_core] llm type: {type(llm)}")
+
+    raw_response = llm.get_completion(prompt)
+    if DEBUG:
+        print(f"[qa_core] raw response: {raw_response!r}")
+    try:
+        content, _usage = raw_response
+    except Exception as e:
+        if DEBUG:
+            print(f"[qa_core] error unpacking response: {e}")
+        raise
     ans = (content or "").strip()
 
     # 4) Re-number bracket markers [n] in the answer to reflect the order they first appear


### PR DESCRIPTION
## Summary
- log prompt, llm type, and raw response before unpacking to help diagnose LLM issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a68642ac8328a2b9154a3ddcf0d1