### PR TITLE
Handle LLM responses without usage metadata

### DIFF
--- a/qa_core.py
+++ b/qa_core.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Tuple
 # If your project uses a different path, update this import accordingly.
 from search.vector_search import search
 
-# Use the Utilities' client so the return type is (text, usage)
+# Use the Utilities' client; typically returns (text, usage)
 from answer_composer import CompletionsClient
 from prompts import load_prompts
 
@@ -141,12 +141,10 @@ def answer_question(
     raw_response = llm.get_completion(prompt)
     if DEBUG:
         print(f"[qa_core] raw response: {raw_response!r}")
-    try:
-        content, _usage = raw_response
-    except Exception as e:
-        if DEBUG:
-            print(f"[qa_core] error unpacking response: {e}")
-        raise
+    if isinstance(raw_response, tuple):
+        content = raw_response[0]
+    else:
+        content = raw_response
     ans = (content or "").strip()
 
     # 4) Re-number bracket markers [n] in the answer to reflect the order they first appear

--- a/rfp_docx_slot_finder.py
+++ b/rfp_docx_slot_finder.py
@@ -69,9 +69,13 @@ def _call_llm(prompt: str, json_output: bool = False) -> str:
     """Call the selected LLM framework and record usage."""
     if FRAMEWORK == "aladdin":
         client = CompletionsClient(model=MODEL)
-        content, usage = client.get_completion(prompt, json_output=json_output)
+        resp = client.get_completion(prompt, json_output=json_output)
     else:
-        content, usage = get_openai_completion(prompt, MODEL, json_output=json_output)
+        resp = get_openai_completion(prompt, MODEL, json_output=json_output)
+    if isinstance(resp, tuple):
+        content, usage = resp
+    else:
+        content, usage = resp, {}
     try:
         _record_usage(MODEL, usage)
     except Exception:


### PR DESCRIPTION
## Summary
- Relax response unpacking in `qa_core.answer_question` to allow LLM clients that return only text
- Make `_call_llm` in `rfp_docx_slot_finder` tolerant of responses missing usage metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a9f596408328bb10e5785df8ab7b