### PR TITLE
Add write_excel_answers Excel helper

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,6 @@
 # Marks rfp_utils as a package
+from .rfp_xlsx_apply_answers import write_excel_answers
+
 __all__ = [
     "qa_core",
     "my_module",
@@ -11,3 +13,5 @@ __all__ = [
     "answer_composer",
     "word_comments",
 ]
+
+__all__.extend(["write_excel_answers"])

--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -1,17 +1,119 @@
-"""Placeholder apply-answers module for .xlsx files.
-
-Currently only extraction of text/formatting is supported.  This module
-exists so that ``rfp_handlers`` can register an answer applier for the
-``.xlsx`` extension.  The function defined here simply raises
-``NotImplementedError``.
-"""
 from __future__ import annotations
 
-from typing import Dict
+import os
+from typing import List, Dict, Any, Optional, Callable
+
+from openpyxl import load_workbook
+from openpyxl.comments import Comment
 
 
-def apply_answers_to_xlsx(xlsx_path: str, slots_json: str, answers_json: str, out_path: str) -> Dict[str, str]:
-    raise NotImplementedError("Excel answer application not yet implemented")
+def _to_text_and_citations(ans: object) -> tuple[str, Dict[str, str]]:
+    """Normalize answer objects to (text, {cit_num -> snippet})."""
+    if isinstance(ans, dict):
+        text = str(ans.get("text", ""))
+        raw = ans.get("citations") or {}
+        cits: Dict[str, str] = {}
+        for k, v in raw.items():
+            key = str(k)
+            if isinstance(v, dict):
+                cits[key] = v.get("text") or v.get("snippet") or v.get("content") or str(v)
+            else:
+                cits[key] = str(v)
+        return text, cits
+    return str(ans or ""), {}
 
 
-__all__ = ["apply_answers_to_xlsx"]
+def write_excel_answers(
+    schema: List[Dict[str, Any]],
+    answers: List[object],
+    source_xlsx_path: str,
+    out_xlsx_path: str,
+    *,
+    mode: str = "fill",  # "fill" | "replace" | "append"
+    generator: Optional[Callable[..., object]] = None,
+    include_comments: Optional[bool] = None,  # defaults to env RFP_INCLUDE_COMMENTS
+) -> Dict[str, int]:
+    """
+    Drop‑in replacement for the old CLI helper. Applies answers into the Excel file.
+
+    schema[i] is expected to include:
+      - 'sheet' (or 'sheet_name')
+      - 'answer_cell' (fallback: 'question_cell' / 'cell' / 'address')
+      - 'question_text' (used only if we need to generate a missing answer)
+
+    answers[i] can be a string or a dict like:
+      {"text": "...", "citations": {1: "snippet", 2: "snippet", ...}}
+    """
+    inc_comments = (
+        (os.getenv("RFP_INCLUDE_COMMENTS", "1") == "1")
+        if include_comments is None
+        else bool(include_comments)
+    )
+
+    wb = load_workbook(source_xlsx_path)
+    ws_by_name = {ws.title: ws for ws in wb.worksheets}
+
+    applied = 0
+    skipped = 0
+
+    # Ensure answers aligns with schema (allow None entries and generate if a generator is provided)
+    if len(answers) < len(schema):
+        answers = answers + [None] * (len(schema) - len(answers))
+
+    for idx, ent in enumerate(schema):
+        sheet_name = ent.get("sheet") or ent.get("sheet_name")
+        addr = (
+            ent.get("answer_cell")
+            or ent.get("question_cell")
+            or ent.get("cell")
+            or ent.get("address")
+        )
+
+        if not sheet_name or not addr:
+            skipped += 1
+            continue
+
+        ws = ws_by_name.get(sheet_name) or wb.active
+        cell = ws[addr]
+
+        ans = answers[idx]
+        if ans is None and generator:
+            q = (ent.get("question_text") or "").strip()
+            ans = generator(q)
+
+        text, citations = _to_text_and_citations(ans)
+
+        if mode == "replace":
+            cell.value = text
+        elif mode == "append":
+            prior = cell.value or ""
+            cell.value = (prior + ("\n" if prior else "") + text)
+        else:  # "fill" (default)
+            # If cell is blank write; otherwise append on a new line to avoid clobbering
+            if cell.value is None or str(cell.value).strip() == "":
+                cell.value = text
+            else:
+                cell.value = f"{cell.value}\n{text}"
+
+        # Wrap long text
+        try:
+            cell.alignment = cell.alignment.copy(wrap_text=True)
+        except Exception:
+            pass
+
+        # Put citations into a single Excel comment
+        if inc_comments and citations:
+            try:
+                comment_txt = "\n\n".join(str(v) for v in citations.values())
+                cell.comment = Comment(comment_txt, "RFPBot")
+            except Exception:
+                pass
+
+        applied += 1
+
+    wb.save(out_xlsx_path)
+    return {"applied": applied, "skipped": skipped, "total": len(schema)}
+
+
+__all__ = ["write_excel_answers"]
+


### PR DESCRIPTION
## Summary
- replace placeholder with write_excel_answers utility for applying RFP answers into Excel workbooks
- expose write_excel_answers at package level

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7736a4358832892a3b1a3e144e25b