### PR TITLE
feat: add LLM-based Excel question detection

### DIFF
--- a/prompts/xlsx_classify_cells.txt
+++ b/prompts/xlsx_classify_cells.txt
@@ -1,0 +1,6 @@
+You are classifying spreadsheet cells.
+Each item below is a JSON object with keys `cell`, `text`, and `features`.
+Label each as `QUESTION_HEADER`, `QUESTION_BODY`, or `NOT_QUESTION`.
+Return only JSON: a list like [{"cell": "A1", "label": "QUESTION_BODY", "confidence": 0.9}, ...].
+Cells:
+{{cells}}


### PR DESCRIPTION
## Summary
- add feature extraction to capture Excel cell styles and text
- integrate LLM-based cell classification with batching prompt
- provide helper to extract question cells via LLM

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77e99c37483289067095b26e30488