### PR TITLE
Auto-update TOC in generated comments doc

### DIFF
--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -177,8 +177,13 @@ def write_excel_answers(
     if inc_comments and comments_docx_path and doc_entries:
         try:
             doc = docx.Document()
+            # Auto-populate fields (like TOC) when opened in Word
+            update = OxmlElement("w:updateFields")
+            update.set(qn("w:val"), "true")
+            doc.settings._element.append(update)
+
             # First page: table of contents
-            doc.add_paragraph("Table of Contents", style="Heading 1")
+            doc.add_paragraph("Table of Contents", style="Title")
             p_toc = doc.add_paragraph()
             run = p_toc.add_run()
             fld = OxmlElement("w:fldSimple")


### PR DESCRIPTION
## Summary
- ensure Word automatically populates table of contents on open
- avoid including the TOC heading as a linkable entry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa74e84d048328806e33d3f90cee70