### PR TITLE
Fix Excel answers write call in CLI

### DIFF
--- a/cli_app.py
+++ b/cli_app.py
@@ -254,7 +254,8 @@ def main():
             answers.append(ans)
 
         out_path = Path(args.output or infile.with_name(infile.stem + "_answered.xlsx"))
-        write_excel_answers(schema, answers, out_path)
+        # write_excel_answers expects both source and destination paths.
+        write_excel_answers(schema, answers, str(infile), str(out_path))
         print(f"[DEBUG] Wrote filled Excel to {out_path}")
         sys.exit(0)
 


### PR DESCRIPTION
## Summary
- pass both source and destination file paths when writing Excel answers in CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab924235e88328b834870f94eafb08