### PR TITLE
Add LLM search for uploaded documents

### DIFF
--- a/cli_app.py
+++ b/cli_app.py
@@ -231,6 +231,7 @@ def _make_docx_generator(
     min_confidence: float,
     include_citations_in_text: bool,
     llm: CompletionsClient,
+    extra_docs: Optional[List[str]] = None,
 ) -> Callable[[str], str]:
     """
     Returns a callable(question)->answer_text suitable for rfp_docx_apply_answers.apply_answers_tb_docx.
@@ -245,6 +246,7 @@ def _make_docx_generator(
             approx_words,
             min_confidence,
             llm,
+            extra_docs=extra_docs,
         )
         if not include_citations_in_text:
             ans = re.sub(r"[\[\d+\]]", "", ans)
@@ -274,6 +276,7 @@ def main():
     group.add_argument("--length", choices=["short", "medium", "long"], help="Preset length")
     group.add_argument("--approx_words", type=int, help="Approximate word count")
     parser.add_argument("--no_comments", action="store_true", help="Disable citations")
+    parser.add_argument("--extra-doc", dest="extra_docs", action="append", help="Additional document to include via LLM search")
 
     parser.add_argument("--search_mode", choices=["answer", "question", "blend", "dual", "both"], default="dual")
     parser.add_argument("--llm_model", choices=["gpt-3.5-turbo", "gpt-4"], default="gpt-4o")
@@ -307,6 +310,7 @@ def main():
             min_confidence=args.min_confidence,
             include_citations_in_text=not args.no_comments,
             llm=CompletionsClient(model=os.environ.get("OPENAI_MODEL", "gpt-4o")),
+            extra_docs=args.extra_docs,
         )
         gen_name = "cli_app:gen"
 
@@ -401,6 +405,7 @@ def main():
                 min_confidence=args.min_confidence,
                 include_citations_in_text=not args.no_comments,
                 llm=llm,
+                extra_docs=args.extra_docs,
             )
             gen_name = "cli_app:rag_gen"
 

--- a/llm_doc_search.py
+++ b/llm_doc_search.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Iterable
+
+from docx import Document
+from PyPDF2 import PdfReader
+
+from answer_composer import CompletionsClient
+from prompts import read_prompt
+
+
+SEARCH_PROMPT = read_prompt(
+    "llm_doc_search",
+    (
+        "You will be given a user question and a chunk of text from an uploaded document. "
+        "If the chunk contains information that helps answer the question, "
+        "respond with 'YES:' followed by only the relevant excerpt. "
+        "Otherwise respond with 'NO'."
+    ),
+)
+
+
+def _extract_text_from_doc(path: str) -> str:
+    """Extract plain text from a .docx or .pdf file."""
+    ext = Path(path).suffix.lower()
+    if ext == ".docx":
+        doc = Document(path)
+        return "\n".join(p.text for p in doc.paragraphs)
+    if ext == ".pdf":
+        reader = PdfReader(path)
+        parts = []
+        for page in reader.pages:
+            txt = page.extract_text() or ""
+            parts.append(txt)
+        return "\n".join(parts)
+    raise ValueError(f"Unsupported file type: {path}")
+
+
+def _iter_chunks(text: str, chunk_size: int = 500, overlap: int = 50) -> Iterable[str]:
+    words = text.split()
+    step = max(1, chunk_size - overlap)
+    for i in range(0, len(words), step):
+        yield " ".join(words[i:i + chunk_size])
+
+
+def search_uploaded_docs(
+    question: str,
+    doc_paths: List[str],
+    llm: CompletionsClient,
+    chunk_size: int = 500,
+    overlap: int = 50,
+    context_pad: int = 50,
+) -> List[Dict]:
+    """Return LLM-retrieved snippets from uploaded documents.
+
+    Each hit mirrors the structure returned by the vector search module:
+    {"text": snippet, "meta": {"source": path}, "cosine": 1.0}
+    """
+    hits: List[Dict] = []
+    for path in doc_paths:
+        try:
+            text = _extract_text_from_doc(path)
+        except Exception:
+            continue
+        for chunk in _iter_chunks(text, chunk_size=chunk_size, overlap=overlap):
+            prompt = (
+                f"{SEARCH_PROMPT}\n\nQuestion: {question}\n\nChunk:\n{chunk}\n"
+            )
+            raw = llm.get_completion(prompt)
+            content = raw[0] if isinstance(raw, tuple) else raw
+            if not isinstance(content, str):
+                continue
+            reply = content.strip()
+            if reply.upper().startswith("YES:"):
+                snippet = reply[4:].strip()
+                lower_chunk = chunk.lower()
+                idx = lower_chunk.find(snippet.lower())
+                if idx >= 0:
+                    start = max(0, idx - context_pad)
+                    end = min(len(chunk), idx + len(snippet) + context_pad)
+                    snippet = chunk[start:end]
+                hits.append({
+                    "text": snippet,
+                    "meta": {"source": str(path)},
+                    "cosine": 1.0,
+                })
+    return hits

--- a/prompts/llm_doc_search.txt
+++ b/prompts/llm_doc_search.txt
@@ -1,0 +1,4 @@
+You will be given a user question and a chunk of text from an uploaded document.
+The question will appear as "Question:" and the text chunk will follow "Chunk:".
+If the chunk contains information that helps answer the question, respond with "YES:" followed by only the relevant excerpt from the chunk.
+If the chunk does not provide relevant information, respond with "NO".

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 requests==2.32.3
 spacy==3.7.4
+
+PyPDF2==3.0.1

--- a/tests/test_llm_doc_search.py
+++ b/tests/test_llm_doc_search.py
@@ -1,0 +1,25 @@
+import sys, pathlib
+from docx import Document
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from llm_doc_search import search_uploaded_docs
+
+
+class DummyLLM:
+    def get_completion(self, prompt: str):
+        if "Project Apollo is top secret." in prompt:
+            return "YES: Project Apollo is top secret."
+        return "NO"
+
+
+def test_search_uploaded_docs_docx(tmp_path):
+    doc = Document()
+    doc.add_paragraph("Project Apollo is top secret.")
+    path = tmp_path / "sample.docx"
+    doc.save(path)
+
+    llm = DummyLLM()
+    hits = search_uploaded_docs("What is Project Apollo?", [str(path)], llm)
+    assert hits
+    assert "Project Apollo is top secret." in hits[0]["text"]


### PR DESCRIPTION
## Summary
- Allow `answer_question` to merge vector hits with an LLM-based search across user-supplied PDFs and DOCX files
- Expose uploaded documents via new `--extra-doc` CLI flag
- Add `llm_doc_search` utility and unit test for document scanning
- Load document-search instructions from a prompt template under `prompts/`

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9f4889dc832889f1b0e8a3f55b42