### PR TITLE
Add progress indicator during dependency installation

### DIFF
--- a/streamlit_app.ipynb
+++ b/streamlit_app.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import subprocess\n",
     "import sys\n",
+    "import streamlit as st\n",
     "\n",
     "# Install all packages without specific versions\n",
     "packages = [\n",
@@ -27,12 +28,17 @@
     "    \"spacy\"\n",
     "]\n",
     "\n",
-    "for package in packages:\n",
+    "progress_bar = st.progress(0, text=\"Installing dependencies...\")\n",
+    "total = len(packages)\n",
+    "for i, package in enumerate(packages, start=1):\n",
+    "    progress_bar.progress(int((i - 1) / total * 100), text=f\"Installing {package}...\")\n",
     "    try:\n",
     "        subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", package])\n",
-    "        print(f\"Successfully installed {package}\")\n",
     "    except subprocess.CalledProcessError as e:\n",
-    "        print(f\"Failed to install {package}: {e}\")\n"
+    "        st.error(f\"Failed to install {package}: {e}\")\n",
+    "    progress_bar.progress(int(i / total * 100), text=f\"Installed {package}\")\n",
+    "progress_bar.progress(100, text=\"Installation complete\")\n",
+    "st.success(\"Dependencies installed.\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Show Streamlit progress bar while installing dependencies at startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb7f8a5948328a732f7904e9778f5