### PR TITLE
Fix answer_composer import path

### DIFF
--- a/cli_app.py
+++ b/cli_app.py
@@ -9,7 +9,7 @@ Modes by input type:
 - PDF/TXT (and DOCX with --doc-as-text): extract questions as text, answer, and build a Q/A Word report
 
 Dependencies in this repo:
-- answer/answer_composer.CompletionsClient
+- answer_composer.CompletionsClient
 - search/vector_search.search
 - rfp_docx_slot_finder.extract_slots_from_docx
 - rfp_docx_apply_answers.apply_answers_to_docx
@@ -41,7 +41,7 @@ from input_file_reader.interpreter_sheet import (
     collect_non_empty_cells
 )
 
-from answer.answer_composer import CompletionsClient
+from answer_composer import CompletionsClient
 from search.vector_search import search
 
 # Restore sys.path

--- a/streamlit_app.ipynb
+++ b/streamlit_app.ipynb
@@ -62,7 +62,7 @@
     "    build_docx,\n",
     ")\n",
     "from qa_core import answer_question\n",
-    "from answer.answer_composer import CompletionsClient, get_openai_completion\n",
+    "from answer_composer import CompletionsClient, get_openai_completion\n",
     "from input_file_reader.interpreter_sheet import collect_non_empty_cells\n",
     "from rfp_xlsx_slot_finder import ask_sheet_schema\n",
     "from rfp_xlsx_apply_answers import write_excel_answers\n",


### PR DESCRIPTION
## Summary
- fix answer_composer import in CLI app
- update Streamlit app to use answer_composer directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbf1ea27483289431a2424ce8d85f