### PR TITLE
Respect framework-specific credentials in XLSX slot finder

### DIFF
--- a/rfp_xlsx_slot_finder.py
+++ b/rfp_xlsx_slot_finder.py
@@ -201,12 +201,34 @@ def _llm_choose_answer_slot(
     -------
     (sheet_name, cell_address):
         The selected sheet and cell address for the answer.  ``(None, None)`` is
-        returned if the model cannot pick a location or the API key is missing.
+        returned if the model cannot pick a location or the environment lacks
+        credentials for the selected framework.
     """
 
-    if not os.getenv("OPENAI_API_KEY"):
+    if FRAMEWORK == "openai":
+        if not os.getenv("OPENAI_API_KEY"):
+            if debug:
+                print("  OPENAI_API_KEY not set for openai; skipping LLM call")
+            return None, None
+    elif FRAMEWORK == "aladdin":
+        required = [
+            "aladdin_studio_api_key",
+            "defaultWebServer",
+            "aladdin_user",
+            "aladdin_passwd",
+        ]
+        missing = [v for v in required if not os.getenv(v)]
+        if missing:
+            if debug:
+                print(
+                    "  Missing environment variables for aladdin: "
+                    + ", ".join(missing)
+                    + "; skipping LLM call"
+                )
+            return None, None
+    else:
         if debug:
-            print("  OPENAI_API_KEY not set; skipping LLM call")
+            print(f"  Unsupported framework {FRAMEWORK}; skipping LLM call")
         return None, None
 
     payload = {"question": question_ctx, "sheets": sheets}

--- a/tests/test_llm_choose_answer_slot.py
+++ b/tests/test_llm_choose_answer_slot.py
@@ -1,0 +1,54 @@
+import rfp_xlsx_slot_finder as finder
+
+
+def test_aladdin_llm_call_without_openai_key(monkeypatch):
+    """Ensure Aladdin framework does not require OPENAI_API_KEY."""
+
+    # Provide the credentials expected by the Aladdin client
+    monkeypatch.setenv("aladdin_studio_api_key", "key")
+    monkeypatch.setenv("defaultWebServer", "server")
+    monkeypatch.setenv("aladdin_user", "user")
+    monkeypatch.setenv("aladdin_passwd", "pass")
+
+    # Explicitly remove any OpenAI key
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # Force the framework to aladdin
+    monkeypatch.setattr(finder, "FRAMEWORK", "aladdin")
+
+    # Track whether the LLM helper was invoked
+    called = {}
+
+    def fake_call_llm(prompt_file, payload, *, model):
+        called["was_called"] = True
+        return {"sheet": "Sheet1", "answer_cell": "B1"}
+
+    monkeypatch.setattr(finder, "_call_llm", fake_call_llm)
+
+    sheet, cell = finder._llm_choose_answer_slot(
+        {"question_cell": "A1"}, {}, model="test-model", debug=False
+    )
+
+    assert called.get("was_called"), "LLM call was skipped for aladdin framework"
+    assert (sheet, cell) == ("Sheet1", "B1")
+
+
+def test_openai_requires_api_key(monkeypatch):
+    """OpenAI framework should skip when OPENAI_API_KEY is missing."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(finder, "FRAMEWORK", "openai")
+
+    called = {}
+
+    def fake_call_llm(prompt_file, payload, *, model):
+        called["was_called"] = True
+        return {}
+
+    monkeypatch.setattr(finder, "_call_llm", fake_call_llm)
+
+    sheet, cell = finder._llm_choose_answer_slot({}, {}, model="test-model", debug=False)
+
+    assert not called.get("was_called")
+    assert (sheet, cell) == (None, None)
+


### PR DESCRIPTION
## Summary
- guard LLM slot selection with framework-specific credential checks
- add tests ensuring OpenAI requires OPENAI_API_KEY while Aladdin works without it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf5dc752c8328a8cc9a605b14d724