### PR TITLE
Remove citation markers from Excel answers

### DIFF
--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -107,18 +107,20 @@ def write_excel_answers(
             ans = generator(q)
 
         text, citations = _to_text_and_citations(ans)
+        excel_text = _CITATION_RE.sub("", text)
+        excel_text = re.sub(r"\s{2,}", " ", excel_text).strip()
 
         if mode == "replace":
-            cell.value = text
+            cell.value = excel_text
         elif mode == "append":
             prior = cell.value or ""
-            cell.value = (prior + ("\n" if prior else "") + text)
+            cell.value = (prior + ("\n" if prior else "") + excel_text)
         else:  # "fill" (default)
             # If cell is blank write; otherwise append on a new line to avoid clobbering
             if cell.value is None or str(cell.value).strip() == "":
-                cell.value = text
+                cell.value = excel_text
             else:
-                cell.value = f"{cell.value}\n{text}"
+                cell.value = f"{cell.value}\n{excel_text}"
 
         # Wrap long text
         try:

--- a/tests/test_xlsx_extraction.py
+++ b/tests/test_xlsx_extraction.py
@@ -89,6 +89,7 @@ def test_comment_formats_citations(tmp_path):
     wb2 = openpyxl.load_workbook(out_path)
     c = wb2["Sheet1"]["B1"]
     assert c.comment is None
+    assert c.value == "Ans"
 
     import docx
     from word_comments import ensure_comments_part
@@ -130,4 +131,6 @@ def test_default_comments_docx_path(tmp_path):
     assert comments_path.exists()
 
     wb2 = openpyxl.load_workbook(out_path)
-    assert wb2["Sheet1"]["B1"].comment is None
+    c = wb2["Sheet1"]["B1"]
+    assert c.comment is None
+    assert c.value == "Ans"


### PR DESCRIPTION
## Summary
- Strip `[n]` citation markers from text written to Excel cells
- Preserve full answers with citations for generating Word comments
- Assert Excel cells contain cleaned text in tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad154fb6f48328823b9d54c6c6231e