### PR TITLE
Retry generating blank Excel answers

### DIFF
--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -110,6 +110,13 @@ def write_excel_answers(
         excel_text = _CITATION_RE.sub("", text)
         excel_text = re.sub(r"\s{2,}", " ", excel_text).strip()
 
+        if not excel_text and generator:
+            q = (ent.get("question_text") or "").strip()
+            ans = generator(q)
+            text, citations = _to_text_and_citations(ans)
+            excel_text = _CITATION_RE.sub("", text)
+            excel_text = re.sub(r"\s{2,}", " ", excel_text).strip()
+
         if mode == "replace":
             cell.value = excel_text
         elif mode == "append":


### PR DESCRIPTION
## Summary
- retry answer generation when Excel text is blank
- test that blank answers trigger a regeneration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1ac573b48328b34fdc31f687eaad