### PR TITLE
Handle comma-separated citation markers

### DIFF
--- a/prompts/answer_llm_template.txt
+++ b/prompts/answer_llm_template.txt
@@ -11,4 +11,4 @@ Context:
 Question:
 {question}
 
-Answer (remember to cite sources with bracket numbers):
+Answer (remember to cite sources with bracket numbers, each citation in its own bracket like [1] [2]):


### PR DESCRIPTION
## Summary
- split combined citation markers like `[1,2]` into separate `[1] [2]` runs when applying answers to DOCX/XLSX
- instruct answer template to keep each citation number in its own bracket

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d3664a083289c440566b98beab8