### PR TITLE
Preserve citation-only Excel answers

### DIFF
--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -110,6 +110,8 @@ def write_excel_answers(
         text, citations = _to_text_and_citations(ans)
         excel_text = _CITATION_RE.sub("", text)
         excel_text = re.sub(r"\s{2,}", " ", excel_text).strip()
+        if not excel_text and text.strip():
+            excel_text = text.strip()
 
         if not excel_text and generator:
             q = (ent.get("question_text") or "").strip()
@@ -117,6 +119,8 @@ def write_excel_answers(
             text, citations = _to_text_and_citations(ans)
             excel_text = _CITATION_RE.sub("", text)
             excel_text = re.sub(r"\s{2,}", " ", excel_text).strip()
+            if not excel_text and text.strip():
+                excel_text = text.strip()
 
         if mode == "replace":
             cell.value = excel_text

--- a/tests/test_xlsx_extraction.py
+++ b/tests/test_xlsx_extraction.py
@@ -107,7 +107,7 @@ def test_comment_formats_citations(tmp_path):
     assert "<w:b/>" in xml
 
 
-def test_regenerates_blank_answer(tmp_path):
+def test_preserves_pure_citation_answer(tmp_path):
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "Sheet1"
@@ -136,10 +136,10 @@ def test_regenerates_blank_answer(tmp_path):
         schema, answers, str(in_path), str(out_path), generator=generator
     )
 
-    assert calls["count"] == 1
+    assert calls["count"] == 0
     wb2 = openpyxl.load_workbook(out_path)
     c = wb2["Sheet1"]["B1"]
-    assert c.value == "Retry answer"
+    assert c.value == "[1]"
 
 
 def test_default_comments_docx_path(tmp_path):


### PR DESCRIPTION
## Summary
- prevent Excel writer from blanking answers made entirely of citations
- verify citation-only answers remain untouched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad2065806083288cc8813215254ce7