### PR TITLE
Add debug logging for Excel comment DOCX creation

### DIFF
--- a/cli_app.py
+++ b/cli_app.py
@@ -421,14 +421,20 @@ def main():
             if args.output
             else infile.with_name(infile.stem + "_answered.xlsx")
         )
+        comments_path = out_path.with_name(out_path.stem + "_comments.docx")
         write_excel_answers(
             schema,
             answers,
             infile,
             out_path,
             include_comments=not args.no_comments,
+            comments_docx_path=str(comments_path)
+            if not args.no_comments
+            else None,
         )
         print(f"[DEBUG] Wrote filled Excel to {out_path}")
+        if not args.no_comments:
+            print(f"[DEBUG] Wrote citation comments DOCX to {comments_path}")
         sys.exit(0)
 
     # — DOCX flow (apply answers into the template) ————————

--- a/rfp_xlsx_apply_answers.py
+++ b/rfp_xlsx_apply_answers.py
@@ -89,9 +89,15 @@ def write_excel_answers(
 
     doc_entries: List[Dict[str, Any]] = []
 
-    if inc_comments and not comments_docx_path:
-        base, _ = os.path.splitext(out_xlsx_path)
-        comments_docx_path = base + "_comments.docx"
+    if inc_comments:
+        if not comments_docx_path:
+            base, _ = os.path.splitext(out_xlsx_path)
+            comments_docx_path = base + "_comments.docx"
+        print(
+            f"[DEBUG] Citation comments enabled; DOCX will be written to {comments_docx_path}"
+        )
+    else:
+        print("[DEBUG] Citation comments disabled; no DOCX will be created")
 
     # Ensure answers aligns with schema (allow None entries and generate if a generator is provided)
     if len(answers) < len(schema):
@@ -162,6 +168,7 @@ def write_excel_answers(
 
     wb.save(out_xlsx_path)
     wb.close()
+    print(f"[DEBUG] Saved output workbook to {out_xlsx_path}")
 
     if inc_comments and comments_docx_path and doc_entries:
         try:
@@ -223,8 +230,15 @@ def write_excel_answers(
                 if idx < len(doc_entries):
                     doc.add_page_break()
             doc.save(comments_docx_path)
-        except Exception:
-            pass
+            print(
+                f"[DEBUG] Saved comments DOCX to {comments_docx_path} with {len(doc_entries)} entries"
+            )
+        except Exception as e:
+            print(
+                f"[DEBUG] Failed to write comments DOCX to {comments_docx_path}: {e}"
+            )
+    elif inc_comments and comments_docx_path:
+        print("[DEBUG] No citation entries collected; comments DOCX not created")
 
     return {"applied": applied, "skipped": skipped, "total": len(schema)}
 


### PR DESCRIPTION
## Summary
- log where citation comments DOCX will be written in `write_excel_answers`
- announce when Excel and comment DOCX files are saved in CLI and helper

## Testing
- `pytest -q` *(fails: Package has no attribute partname_for; missing comments docx; skipped count mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ebc8206c8328939a008a0157f349