### PR TITLE
Set Ask a Question as default in Streamlit app

### DIFF
--- a/streamlit_app.ipynb
+++ b/streamlit_app.ipynb
@@ -148,7 +148,7 @@
     "def main():\n",
     "    st.title(\"RFP Responder\")\n",
     "    view_mode = st.sidebar.radio(\"Interface mode\", [\"User\", \"Developer\"], index=0)\n",
-    "    input_mode = st.radio(\"How would you like to proceed?\", [\"Upload document\", \"Ask a question\"], horizontal=True)\n",
+    "    input_mode = st.radio(\"How would you like to proceed?\", [\"Upload document\", \"Ask a question\"], index=1, horizontal=True)\n",
     "\n",
     "    framework_env = os.getenv(\"ANSWER_FRAMEWORK\")\n",
     "    if framework_env:\n",


### PR DESCRIPTION
## Summary
- Default Streamlit interface to "Ask a question" instead of uploading a document.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62471392c8328b570b339a6b11b28