### PR TITLE
Avoid automatic concluding summaries in answers

### DIFF
--- a/prompts/answer_llm.txt
+++ b/prompts/answer_llm.txt
@@ -1,4 +1,4 @@
-You are answering RFP questions using the context snippets below. When you borrow facts, cite with bracketed numbers like [1], [2] that refer to the numbered context items. Use the exact wording from the context whenever possible, making only minimal edits for grammar or flow. Each sentence should rely on a cited snippet and avoid introducing information not present in the context.
+You are answering RFP questions using the context snippets below. When you borrow facts, cite with bracketed numbers like [1], [2] that refer to the numbered context items. Use the exact wording from the context whenever possible, making only minimal edits for grammar or flow. Each sentence should rely on a cited snippet and avoid introducing information not present in the context. Do not append generic closing summaries such as "In summary" unless the question explicitly requests one.
 
 CONTEXT:
 {context}

--- a/prompts/answer_llm_template.txt
+++ b/prompts/answer_llm_template.txt
@@ -4,6 +4,7 @@ Preserve all technical / financial terminology exactly as written in the context
 Quote passages verbatim and cite them with their bracket numbers.
 Structure the answer clearly (paragraphs, bullets, sub-headings).
 Write as much as is reasonably required to respond fully.
+Do not append generic closing summaries such as "In summary" unless the question explicitly requests one.
 
 Context:
 {context}

--- a/qa_core.py
+++ b/qa_core.py
@@ -181,6 +181,16 @@ def answer_question(
             content = raw_response
         ans = (content or "").strip()
 
+        # Strip a trailing "In summary" section unless the question explicitly
+        # requests a summary. Some models tend to append a concluding paragraph
+        # beginning with this phrase, which users found redundant.
+        if "summary" not in q.lower():
+            idx_summary = ans.lower().rfind("in summary")
+            if idx_summary != -1:
+                if DEBUG:
+                    print("[qa_core] stripping trailing 'In summary' section")
+                ans = ans[:idx_summary].rstrip()
+
         # 4) Re-number bracket markers in the answer to reflect the order they first appear
         order: List[str] = []
         for m in CITATION_RE.finditer(ans):


### PR DESCRIPTION
## Summary
- prevent language model answers from appending an automatic “In summary” section unless the question explicitly requests it
- update answer prompts to discourage generic closing summaries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62ea1be608328a8b1d1e98eb355e3