### PR TITLE
Return fallback message when no sources found

### DIFF
--- a/my_module.py
+++ b/my_module.py
@@ -16,6 +16,9 @@ LENGTH_PRESET    = os.getenv("RFP_LENGTH") or "medium"       # "short"|"medium"|
 APPROX_WORDS_ENV = os.getenv("RFP_APPROX_WORDS")             # if set, overrides LENGTH
 INCLUDE_COMMENTS = os.getenv("RFP_INCLUDE_COMMENTS", "1") == "1"  # "0" to disable
 
+# Message returned when no supporting sources are found.
+NO_SOURCES_MSG = "Sorry, couldn't find relevant information in the sources."
+
 _llm_client = CompletionsClient(model=MODEL)
 
 # Maintain history of prior interactions so follow-ups can reuse context.
@@ -302,6 +305,9 @@ def gen_answer(
                 _llm_client,
                 **kwargs,
             )
+
+        if not cmts:
+            ans = NO_SOURCES_MSG
 
     QUESTION_HISTORY.append(question)
     QA_HISTORY.append({"question": question, "answer": ans, "citations": cmts})

--- a/tests/test_no_comment_fallback.py
+++ b/tests/test_no_comment_fallback.py
@@ -1,0 +1,37 @@
+import sys, pathlib, types
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub external dependencies to avoid import-time failures
+fake_ac = types.ModuleType("answer_composer")
+
+class DummyClient:
+    def __init__(self, model: str | None = None):
+        pass
+
+    def get_completion(self, prompt: str, json_output: bool = False):
+        return "", {}
+
+fake_ac.CompletionsClient = DummyClient
+fake_ac.get_openai_completion = lambda prompt, model, json_output=False: ("", {})
+sys.modules["answer_composer"] = fake_ac
+
+fake_search = types.ModuleType("search.vector_search")
+fake_search.search = lambda *args, **kwargs: []
+sys.modules["search.vector_search"] = fake_search
+
+import my_module
+
+def test_gen_answer_returns_fallback_when_no_comments(monkeypatch):
+    my_module.QUESTION_HISTORY.clear()
+    my_module.QA_HISTORY.clear()
+
+    def fake_answer_question(q, mode, fund, k, length, approx_words, min_conf, llm, **kwargs):
+        return "Some answer", []
+
+    monkeypatch.setattr(my_module, "answer_question", fake_answer_question)
+
+    res = my_module.gen_answer("Is anything available?")
+    assert res["text"] == my_module.NO_SOURCES_MSG
+    assert res["citations"] == {}


### PR DESCRIPTION
## Summary
- add constant fallback message for missing citations
- ensure `gen_answer` returns fallback when search yields no comments
- cover no-comment path with unit test

## Testing
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74d465264832889c88dd8daf78380