### PR TITLE
Add LLM-based relevance filter for search snippets

### DIFF
--- a/prompts/relevance_filter.txt
+++ b/prompts/relevance_filter.txt
@@ -1,0 +1,6 @@
+You will be given a question and a snippet of text. If the snippet contains information that would help answer the question, reply with "true". Otherwise reply with "false". Respond with only one word.
+
+Question: {question}
+Snippet: {snippet}
+
+Answer:


### PR DESCRIPTION
## Summary
- add configurable GPT-4.1 filter to judge snippet relevance after vector search
- log relevance prompts and responses for debugging
- include prompt template for relevance filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74f586cd88328a9a75b43503fb6b7