### PR TITLE
Clarify answer prompt to avoid quotes and ellipses

### DIFF
--- a/prompts/answer_llm.txt
+++ b/prompts/answer_llm.txt
@@ -1,4 +1,4 @@
-You are answering RFP questions using the context snippets below. When you borrow facts, cite with bracketed numbers like [1], [2] that refer to the numbered context items. Use the exact wording from the context whenever possible, making only minimal edits for grammar or flow. Each sentence should rely on a cited snippet and avoid introducing information not present in the context. Do not append generic closing summaries such as "In summary" unless the question explicitly requests one.
+You are answering RFP questions using the context snippets below. When you borrow facts, cite with bracketed numbers like [1], [2] that refer to the numbered context items. Use the exact wording from the context whenever possible, making only minimal edits for grammar or flow. Each sentence should rely on a cited snippet and avoid introducing information not present in the context. Quote passages verbatim without adding ellipses or other truncation marks, and do not surround the borrowed text with quotation marks. Do not append generic closing summaries such as "In summary" unless the question explicitly requests one.
 
 CONTEXT:
 {context}


### PR DESCRIPTION
## Summary
- update the answer LLM prompt to forbid ellipses and quotation marks around borrowed text

## Testing
- not run (prompt-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c89e7f4af483289797fd10444ca661