### PR TITLE
Fix Streamlit document citation f-string

### DIFF
--- a/streamlit_app.ipynb
+++ b/streamlit_app.ipynb
@@ -422,7 +422,7 @@
     "                    sidebar.markdown(f\"**Answer {answer_idx}**\")\n",
     "                    for lbl, cite in (msg.get(\"citations\") or {}).items():\n",
     "                        with sidebar.expander(str(lbl)):\n",
-    "                            st.markdown(f\"**Document:** {cite.get(\"source_file\", \"Unknown\")}**\")\n",
+    "                            st.markdown(f\"**Document:** {cite.get('source_file', 'Unknown')}**\")\n",
     "                            section = cite.get(\"section\")\n",
     "                            if section:\n",
     "                                st.markdown(f\"**Section:** {section}**\")\n",


### PR DESCRIPTION
## Summary
- correct the citation markdown string in the Streamlit app to use proper quoting inside the f-string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdf293088c8328b3de95e5da54a41a